### PR TITLE
use new geolocation service

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
       # attempt to geocode
       location = request.location
 
-      if zip_code = ZipCode.find_by(zip: location.data['zip_code'])
+      if zip_code = ZipCode.find_by(zip: location.data['zip'])
         session[:area_id] = zip_code.area.id
       else
         # :shrug: bad ZIP?

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -2,7 +2,7 @@ Geocoder.configure(
   # Geocoding options
   # timeout: 3,                 # geocoding service timeout (secs)
   # lookup: :google,            # name of geocoding service (symbol)
-  ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  ip_lookup: :ipapi_com,        # name of IP address geocoding service (symbol)
   # language: :en,              # ISO-639 language code
   # use_https: false,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)


### PR DESCRIPTION
This worked through ngrok using safe_location method on the request.  I believe I needed safe_location due to the nature of ngrok + proxying but in production it would be better to use the plain location method. If we find there are issues, we can switch to safe_location in the future.