### PR TITLE
Fix demanding state demands

### DIFF
--- a/app/controllers/supported_demands_controller.rb
+++ b/app/controllers/supported_demands_controller.rb
@@ -6,7 +6,6 @@ class SupportedDemandsController < ApplicationController
   def create
     @demand = find_demand
     current_user.user_demands.create(demand: @demand)
-    flash[:info] = "You've demanded #{@demand.name}!"
     redirect_to params[:redirect] || demand_url(@demand)
   end
 
@@ -31,6 +30,6 @@ class SupportedDemandsController < ApplicationController
   end
 
   def find_demand
-    user_municipality.demands.find(params[:id])
+    Demand.find(params[:id])
   end
 end

--- a/spec/controllers/supported_demands_controller_spec.rb
+++ b/spec/controllers/supported_demands_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe SupportedDemandsController, type: :controller do
+  before do
+    @experience = BasicLodExperience.new
+
+    @user = @experience.boxford_user_new
+    @user.confirm
+    sign_in @user
+  end
+
+  describe "#create" do
+    before do
+      @demand_to_support = @experience.demands[:boxford_user_boxford_1]
+    end
+
+    it "creates a user_demand for a municipal-level demand" do
+      expect(@user.user_demands).to be_empty
+      post :create, params: { id: @demand_to_support.id }
+
+      expect(@user.user_demands.length).to be(1)
+      expect(@user.user_demands.first.demand_id).to eq(@demand_to_support.id)
+    end
+
+    it "creates a user_demand for a state-level demand" do
+      @demand_to_support = @experience.demands[:boxford_user_mass]
+      expect(@user.user_demands).to be_empty
+      post :create, params: { id: @demand_to_support.id }
+
+      expect(@user.user_demands.length).to be(1)
+      expect(@user.user_demands.first.demand_id).to eq(@demand_to_support.id)
+    end
+
+    it "redirects to correct url when given 'redirect' param" do
+      url = 'foo.bar/baz'
+      post :create, params: { id: @demand_to_support.id, redirect: url }
+
+      expect(response).to redirect_to(url)
+    end
+
+    it "redirects to the newly supported demand when no 'redirect' param is given" do
+      post :create, params: { id: @demand_to_support.id }
+
+      expect(response).to redirect_to(@demand_to_support)
+    end
+  end
+end

--- a/spec/examples.txt
+++ b/spec/examples.txt
@@ -1,19 +1,23 @@
-example_id                                           | status | run_time        |
----------------------------------------------------- | ------ | --------------- |
-./spec/controllers/demands_controller_spec.rb[1:1:1] | passed | 0.05068 seconds |
-./spec/controllers/demands_controller_spec.rb[1:1:2] | passed | 0.3726 seconds  |
-./spec/controllers/demands_controller_spec.rb[1:1:3] | passed | 0.05167 seconds |
-./spec/controllers/search_controller_spec.rb[1:1:1]  | passed | 0.17296 seconds |
-./spec/forms/demand_form_spec.rb[1:1:1]              | passed | 0.02246 seconds |
-./spec/forms/demand_form_spec.rb[1:1:2]              | passed | 0.01998 seconds |
-./spec/forms/demand_form_spec.rb[1:1:3]              | passed | 0.0307 seconds  |
-./spec/forms/demand_form_spec.rb[1:2:1]              | passed | 0.02235 seconds |
-./spec/forms/demand_form_spec.rb[1:2:2]              | passed | 0.02484 seconds |
-./spec/forms/demand_form_spec.rb[1:2:3]              | passed | 0.02373 seconds |
-./spec/forms/demand_form_spec.rb[1:2:4]              | passed | 0.0226 seconds  |
-./spec/forms/demand_form_spec.rb[1:3:1]              | passed | 0.0203 seconds  |
-./spec/forms/demand_form_spec.rb[1:3:2]              | passed | 0.02094 seconds |
-./spec/forms/demand_form_spec.rb[1:4:1]              | passed | 0.01915 seconds |
-./spec/forms/demand_form_spec.rb[1:4:2]              | passed | 0.02362 seconds |
-./spec/forms/demand_form_spec.rb[1:5:1]              | passed | 0.02975 seconds |
-./spec/forms/demand_form_spec.rb[1:5:2]              | passed | 0.02333 seconds |
+example_id                                                     | status | run_time        |
+-------------------------------------------------------------- | ------ | --------------- |
+./spec/controllers/demands_controller_spec.rb[1:1:1]           | passed | 0.03248 seconds |
+./spec/controllers/demands_controller_spec.rb[1:1:2]           | passed | 0.03472 seconds |
+./spec/controllers/demands_controller_spec.rb[1:1:3]           | passed | 0.05161 seconds |
+./spec/controllers/search_controller_spec.rb[1:1:1]            | passed | 0.18143 seconds |
+./spec/controllers/supported_demands_controller_spec.rb[1:1:1] | passed | 0.16242 seconds |
+./spec/controllers/supported_demands_controller_spec.rb[1:1:2] | passed | 0.51386 seconds |
+./spec/controllers/supported_demands_controller_spec.rb[1:1:3] | passed | 0.15291 seconds |
+./spec/controllers/supported_demands_controller_spec.rb[1:1:4] | passed | 0.1639 seconds  |
+./spec/forms/demand_form_spec.rb[1:1:1]                        | passed | 0.0206 seconds  |
+./spec/forms/demand_form_spec.rb[1:1:2]                        | passed | 0.02067 seconds |
+./spec/forms/demand_form_spec.rb[1:1:3]                        | passed | 0.03137 seconds |
+./spec/forms/demand_form_spec.rb[1:2:1]                        | passed | 0.02056 seconds |
+./spec/forms/demand_form_spec.rb[1:2:2]                        | passed | 0.0219 seconds  |
+./spec/forms/demand_form_spec.rb[1:2:3]                        | passed | 0.02298 seconds |
+./spec/forms/demand_form_spec.rb[1:2:4]                        | passed | 0.02458 seconds |
+./spec/forms/demand_form_spec.rb[1:3:1]                        | passed | 0.01996 seconds |
+./spec/forms/demand_form_spec.rb[1:3:2]                        | passed | 0.01852 seconds |
+./spec/forms/demand_form_spec.rb[1:4:1]                        | passed | 0.01985 seconds |
+./spec/forms/demand_form_spec.rb[1:4:2]                        | passed | 0.02159 seconds |
+./spec/forms/demand_form_spec.rb[1:5:1]                        | passed | 0.02515 seconds |
+./spec/forms/demand_form_spec.rb[1:5:2]                        | passed | 0.02266 seconds |

--- a/spec/support/experiences/basic_lod_experience.rb
+++ b/spec/support/experiences/basic_lod_experience.rb
@@ -1,6 +1,6 @@
 class BasicLodExperience
 
-  attr_reader :arlington_user, :bedford_user, :boxford_user, :demands
+  attr_reader :arlington_user, :bedford_user, :boxford_user, :boxford_user_new, :demands
 
   def initialize
     add_area_stuff
@@ -15,9 +15,9 @@ class BasicLodExperience
     @massachusetts = State.create(name: "Massachusetts")
     @essex = County.create(name: "Essex, Massachusetts")
     @middlesex = County.create(name: "Middlesex, Massachusetts")
-    @arlington = Municipality.create(name: "Arlington")
-    @bedford = Municipality.create(name: "Bedford")
-    @boxford = Municipality.create(name: "Boxford")
+    @arlington = Municipality.create(name: "Arlington, Middlesex, Massachusetts")
+    @bedford = Municipality.create(name: "Bedford, Middlesex, Massachusetts")
+    @boxford = Municipality.create(name: "Boxford, Essex, Massachusetts")
 
     @arlington_zip = FactoryBot.create(:zip_code, :arlington)
     @bedford_zip = FactoryBot.create(:zip_code, :bedford)
@@ -32,6 +32,8 @@ class BasicLodExperience
     @arlington_user = FactoryBot.create(:user, profile: FactoryBot.build(:profile, zip: @arlington_zip.zip))
     @bedford_user = FactoryBot.create(:user, profile: FactoryBot.build(:profile, zip: @bedford_zip.zip))
     @boxford_user = FactoryBot.create(:user, profile: FactoryBot.build(:profile, zip: @boxford_zip.zip))
+    # This new user should have no created/supported demands, valuable for testing
+    @boxford_user_new = FactoryBot.create(:user, profile: FactoryBot.build(:profile, zip: @boxford_zip.zip))
   end
 
   def add_demands


### PR DESCRIPTION
**Note**: I had to resolve a merge conflict so the cherry-picked LoD experience commit has a new hash.

Previously, demanding a "state-level" demand was broken because of the lookup in the SupportedDemandsController. I discussed with Juhan, and (for now, at least) we'll allow any user to demand any demand, regardless of area scope.

Knowing that, LMK any suggestion on avoiding the DB lookup with find (if that's an issue).