### PR TITLE
allow unconfirmed user access for 2 days

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -122,7 +122,7 @@ Devise.setup do |config|
   # able to access the website for two days without confirming their account,
   # access will be blocked just in the third day. Default is 0.days, meaning
   # the user cannot access the website without confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 2.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm


### PR DESCRIPTION
Assuming this is all that needs to happen. Successfully manually tested registering new user and signing in as both the new user and old.